### PR TITLE
Use platforms repo for constraints

### DIFF
--- a/sh/posix.bzl
+++ b/sh/posix.bzl
@@ -273,12 +273,12 @@ toolchain(
     toolchain = ":local_posix",
     toolchain_type = "{toolchain_type}",
     exec_compatible_with = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:{os}",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:{os}",
     ],
     target_compatible_with = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:{os}",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:{os}",
     ],
 )
 """.format(

--- a/sh/repositories.bzl
+++ b/sh/repositories.bzl
@@ -10,3 +10,10 @@ def rules_sh_dependencies():
         strip_prefix = "bazel-skylib-1.0.2",
         urls = ["https://github.com/bazelbuild/bazel-skylib/archive/1.0.2.tar.gz"],
     )
+    maybe(
+        http_archive,
+        "platforms",
+        sha256 = "23566db029006fe23d8140d14514ada8c742d82b51973b4d331ee423c75a0bfa",
+        strip_prefix = "platforms-46993efdd33b73649796c5fc5c9efb193ae19d51",
+        urls = ["https://github.com/bazelbuild/platforms/archive/46993efdd33b73649796c5fc5c9efb193ae19d51.tar.gz"],
+    )

--- a/sh/repositories.bzl
+++ b/sh/repositories.bzl
@@ -1,13 +1,12 @@
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def rules_sh_dependencies():
     """Load repositories required by rules_sh."""
-    excludes = native.existing_rules().keys()
-
-    if "bazel_skylib" not in excludes:
-        http_archive(
-            name = "bazel_skylib",
-            sha256 = "e5d90f0ec952883d56747b7604e2a15ee36e288bb556c3d0ed33e818a4d971f2",
-            strip_prefix = "bazel-skylib-1.0.2",
-            urls = ["https://github.com/bazelbuild/bazel-skylib/archive/1.0.2.tar.gz"],
-        )
+    maybe(
+        http_archive,
+        name = "bazel_skylib",
+        sha256 = "e5d90f0ec952883d56747b7604e2a15ee36e288bb556c3d0ed33e818a4d971f2",
+        strip_prefix = "bazel-skylib-1.0.2",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/1.0.2.tar.gz"],
+    )


### PR DESCRIPTION
See https://github.com/tweag/rules_haskell/pull/1196

- Uses `@platforms//<setting>:<value>` instead of `@bazel_tools//platforms:<value>`.
- Loads `@platforms` in `rules_sh_dependencies`.