### PR TITLE
Fix mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
   - name: automatic merge
     conditions:
-      - "status-success=build"
+      - "status-success=buildkite/rules-sh"
       - "#approved-reviews-by>=1"
       - "label=merge-queue"
       - "base=master"


### PR DESCRIPTION
Mergify never merged PRs because the `status-success` condition was
never met. The reason was that the check name `build` was wrong.
This has been fixed following the instructions in the [mergify
documentation][1].

[1]: https://doc.mergify.io/conditions.html#about-status-check-name