### PR TITLE
Define bzl_library for rules_sh

### DIFF
--- a/sh/BUILD.bazel
+++ b/sh/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+# @bazel_tools//tools does not define a bzl_library itself, instead we are
+# supposed to define our own using the @bazel_tools//tools:bzl_srcs filegroup.
+# See https://github.com/bazelbuild/skydoc/issues/166
+bzl_library(
+    name = "bazel_tools",
+    srcs = [
+        "@bazel_tools//tools:bzl_srcs",
+    ],
+)
+
+bzl_library(
+    name = "repositories",
+    srcs = [
+        "repositories.bzl",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bazel_tools",
+    ],
+)
+
+bzl_library(
+    name = "posix",
+    srcs = [
+        "posix.bzl",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bazel_tools",
+        "@bazel_skylib//lib:paths",
+    ],
+)

--- a/sh/posix.bzl
+++ b/sh/posix.bzl
@@ -259,6 +259,7 @@ def _windows_detect_sh_dir(repository_ctx):
             # repository_ctx.which returns a path object, convert that to
             # string so we can call string.startswith on it.
             sh_path = str(sh_path)
+
             # When the Windows Subsystem for Linux is installed there's a
             # bash.exe under %WINDIR%\system32\bash.exe that launches Ubuntu
             # Bash which cannot run native Windows programs so it's not what


### PR DESCRIPTION
`bzl_library` target definitions [are required to generate Stardoc documentation](https://github.com/bazelbuild/stardoc/blob/master/docs/skydoc_deprecation.md#starlark-dependencies) for any rules set that depends on `rules_sh`. This change is motivated by https://github.com/tweag/rules_haskell/pull/1244.
