### PR TITLE
Run CI in Docker container

### DIFF
--- a/.buildkite/image/Dockerfile
+++ b/.buildkite/image/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:xenial-20200114
+RUN apt-get --quiet update \
+ && apt-get --quiet install -y build-essential curl \
+ && rm -rf /var/lib/apt/lists/*
+ARG UID
+ENV UID=$UID
+ARG USER
+ENV USER=$USER
+RUN useradd -ms /bin/bash --uid $UID $USER
+WORKDIR /home/$USER
+USER $USER

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,16 @@
 steps:
   - label: "Run tests"
-    command: .buildkite/run-pipeline
+    command: |
+      (cd .buildkite/image && \
+        docker build \
+          --build-arg UID=$(id -u $USER) \
+          --build-arg USER=$USER \
+          -t tweag/rules_sh:latest \
+          .)
+      docker run -it \
+        --network host \
+        -v $(pwd):/home/$USER/rules_sh:rw \
+        --workdir /home/$USER/rules_sh \
+        tweag/rules_sh:latest \
+        .buildkite/run-pipeline
     timeout: 30


### PR DESCRIPTION
The buildkite workers are now running on NixOS. However, `rules_sh` should be tested outside a Nix environment (`rules_nixpkgs` provides the relevant Nix extensions). We follow `rules_haskell`'s example and run the pipeline in a dedicated Docker container.