### PR TITLE
sh_posix_toolchain: reduce number of attributes by using attr.string_dict instead of attr.string list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 [Unreleased]: https://github.com/tweag/rules_sh/compare/v0.1.1...HEAD
 
+### Changed
+
+- `sh_posix_toolchain` now has a single attribute `cmds`, which
+  is a string to string `dict`; instead of having one attribute
+  per member of `posix.commands`. It is a breaking change if you were
+  calling `sh_posix_toolchain` directly.
+
+  If you were calling this rule as follows:
+
+  ```
+  sh_posix_toolchain(cat = "/bin/cat", wc = "/usr/bin/wc")
+  ```
+
+  you should now do:
+
+  ```
+  sh_posix_toolchain(cmds = { "cat": "/bin/cat", "wc": "/usr/bin/wc" })
+  ```
+
+  See PR [#14][#14] and issue [#13][#13] for the motivation.
+
+[#14]: https://github.com/tweag/rules_sh/pull/14
+[#13]: https://github.com/tweag/rules_sh/issues/13
+
 ## [0.1.1] - 2019-11-13
 
 [0.1.1]: https://github.com/tweag/rules_sh/compare/v0.1.0...v0.1.1

--- a/sh/posix.bzl
+++ b/sh/posix.bzl
@@ -187,6 +187,9 @@ def _sh_posix_toolchain_impl(ctx):
         if not cmd_path:
             cmd_path = None
         commands[cmd] = cmd_path
+    unrecognizeds = [cmd for cmd in cmds.keys() if cmd not in _commands]
+    if unrecognizeds:
+        fail("Unrecognized commands in keys of sh_posix_toolchain's \"cmds\" attributes: {}. See _commands in posix.bzl for the list of recognized commands.".format(", ".join(unrecognizeds)))
     cmd_paths = {
         paths.dirname(cmd_path): None
         for cmd_path in commands.values()

--- a/sh/posix.bzl
+++ b/sh/posix.bzl
@@ -181,7 +181,7 @@ MAKE_VARIABLES = "@rules_sh//sh/posix:make_variables"
 
 def _sh_posix_toolchain_impl(ctx):
     commands = {}
-    cmds = getattr(ctx.attr, "cmds", {})
+    cmds = ctx.attr.cmds
     for cmd in _commands:
         cmd_path = cmds.get(cmd, None)
         if not cmd_path:
@@ -201,7 +201,7 @@ sh_posix_toolchain = rule(
     attrs = {
         "cmds": attr.string_dict(
             doc = "dict where keys are command names and values are paths",
-            mandatory = False,
+            mandatory = True,
         )
     },
     doc = """

--- a/sh/posix.bzl
+++ b/sh/posix.bzl
@@ -189,7 +189,7 @@ def _sh_posix_toolchain_impl(ctx):
         commands[cmd] = cmd_path
     unrecognizeds = [cmd for cmd in cmds.keys() if cmd not in _commands]
     if unrecognizeds:
-        fail("Unrecognized commands in keys of sh_posix_toolchain's \"cmds\" attributes: {}. See _commands in posix.bzl for the list of recognized commands.".format(", ".join(unrecognizeds)))
+        fail("Unrecognized commands in keys of sh_posix_toolchain's \"cmds\" attributes: {}. See posix.commands in @rules_sh//sh:posix.bzl for the list of recognized commands.".format(", ".join(unrecognizeds)))
     cmd_paths = {
         paths.dirname(cmd_path): None
         for cmd_path in commands.values()


### PR DESCRIPTION
This PR fixes #13 

### Tests

* `bazel test //...`
* `bazel test //...` in [rules_nixpkgs](https://github.com/tweag/rules_nixpkgs) with the appropriate patch: https://github.com/tweag/rules_nixpkgs/pull/117
* `bazel test //...` test in [rules_haskell](https://github.com/tweag/rules_haskell) by using `rules_nixpkgs` from the previous bullet
