### PR TITLE
remove target constraints from toolchain in sh_posix_configure

### DIFF
--- a/sh/posix.bzl
+++ b/sh/posix.bzl
@@ -315,10 +315,6 @@ toolchain(
         "@platforms//cpu:x86_64",
         "@platforms//os:{os}",
     ],
-    target_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:{os}",
-    ],
 )
 """.format(
         commands = ",\n        ".join([


### PR DESCRIPTION
As discussed [here](https://github.com/tweag/rules_nixpkgs/pull/163) for rules_nixpkgs, this PR removes the target constraints for the posix toolchain declared by `sh_posix_configure`.