### PR TITLE
"Modularize" rules_sh

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,16 @@
+platforms:
+  centos7:
+    build_targets:
+    - '@rules_sh//...'
+  debian10:
+    build_targets:
+    - '@rules_sh//...'
+  macos:
+    build_targets:
+    - '@rules_sh//...'
+  ubuntu2004:
+    build_targets:
+    - '@rules_sh//...'
+  windows:
+    build_targets:
+    - '@rules_sh//...'

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -8,6 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        bzlmod: [workspace, module]
     defaults:
       run:
         shell: bash
@@ -27,6 +28,15 @@ jobs:
           machine api.github.com
                   password ${{ secrets.GITHUB_TOKEN }}
           EOF
+          if [[ ${{ matrix.bzlmod }} == module ]]; then
+            # Test with bzlmod enabled.
+            # Requires https://github.com/bazelbuild/bazel/commit/302971e1b3d803069ac949c0085c0d2a3916c8ab,
+            # see https://github.com/bazelbuild/bazel-central-registry/pull/47#issuecomment-998883652
+            echo USE_BAZEL_VERSION=302971e1b3d803069ac949c0085c0d2a3916c8ab >.bazeliskrc
+            cat >>.bazelrc.local <<-EOF
+          	build --experimental_enable_bzlmod
+          	EOF
+          fi
       - name: Build & Test
         run: |
           if [[ ${{ runner.os }} == Windows ]]; then

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,8 +2,8 @@
 
 ## Cutting a new release
 
-- Create a dedicated branch: `release-<version>` (e.g. `release-0.2.0`)
-- Check the changes since the last release by
+* Create a dedicated branch: `release-<version>` (e.g. `release-0.2.0`)
+* Check the changes since the last release by
   [comparing the heads](https://github.com/tweag/rules_sh/compare/v0.2.0...HEAD),
   add anything relevant to `CHANGELOG.md`,
   and update the version heading and unreleased heading in `CHANGELOG.md`.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,3 +17,29 @@
   and calling `sha256sum` on it.
 * Update the release notes with a workspace setup section for the new version,
   such as [this example](https://github.com/tweag/rules_sh/releases/tag/v0.2.0)
+* Add the new version to the Bazel Central Registry as described below
+
+## Add a new version to the Bazel Central Registry
+
+* Follow the instructions given in the [README][bcr-add] to add a new version
+  of this module. Use the following input file to `add_module.py` for
+  reference - don't forget to update the version and dependencies:
+  ```
+  {
+      "build_file": null,
+      "build_targets": [],
+      "compatibility_level": "0",
+      "deps": [["bazel_skylib", "1.0.3"], ["platforms", "0.0.4"]],
+      "module_dot_bazel": "path/to/rules_sh/MODULE.bazel",
+      "name": "rules_sh",
+      "patch_strip": 1,
+      "patches": [],
+      "presubmit_yml": "path/to/rules_sh/.bazelci/presubmit.yml",
+      "strip_prefix": "rules_sh-0.2.0",
+      "test_targets": [],
+      "url": "https://github.com/tweag/rules_sh/archive/refs/tags/v0.2.0.tar.gz",
+      "version": "0.2.0"
+  }
+  ```
+
+[bcr-add]: https://github.com/bazelbuild/bazel-central-registry#module-contributor

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "rules_sh",
+    version = "0.2.0",
+    compatibility_level = 0,
+    toolchains_to_register = ["@local_posix_config//:local_posix_toolchain"],
+)
+bazel_dep(name = "bazel_skylib", version = "1.0.3")
+bazel_dep(name = "platforms", version = "0.0.4")
+
+sh_configure = use_extension("@rules_sh//bzlmod:extensions.bzl", "sh_configure")
+use_repo(sh_configure, "local_posix_config")

--- a/bzlmod/extensions.bzl
+++ b/bzlmod/extensions.bzl
@@ -1,6 +1,5 @@
 load("//sh:posix.bzl", "sh_posix_configure")
 
-
 def _sh_configure_impl(ctx):
     sh_posix_configure(register = False)
 

--- a/bzlmod/extensions.bzl
+++ b/bzlmod/extensions.bzl
@@ -1,0 +1,7 @@
+load("//sh:posix.bzl", "sh_posix_configure")
+
+
+def _sh_configure_impl(ctx):
+    sh_posix_configure(register = False)
+
+sh_configure = module_extension(implementation = _sh_configure_impl)

--- a/sh/posix.bzl
+++ b/sh/posix.bzl
@@ -339,7 +339,7 @@ _sh_posix_config = repository_rule(
     implementation = _sh_posix_config_impl,
 )
 
-def sh_posix_configure(name = "local_posix_config"):
+def sh_posix_configure(name = "local_posix_config", register = True):
     """Autodetect local Unix commands.
 
     Scans the environment (`$PATH`) for standard shell commands, generates a
@@ -350,7 +350,8 @@ def sh_posix_configure(name = "local_posix_config"):
     `POSIX_MAKE=/usr/bin/gmake` will override the make command.
     """
     _sh_posix_config(name = name)
-    native.register_toolchains("@{}//:local_posix_toolchain".format(name))
+    if register:
+        native.register_toolchains("@{}//:local_posix_toolchain".format(name))
 
 posix = struct(
     commands = _commands,

--- a/sh/posix.bzl
+++ b/sh/posix.bzl
@@ -205,7 +205,7 @@ sh_posix_toolchain = rule(
         "cmds": attr.string_dict(
             doc = "dict where keys are command names and values are paths",
             mandatory = True,
-        )
+        ),
     },
     doc = """
 A toolchain capturing standard Unix shell commands.


### PR DESCRIPTION
For compatibility with bzlmod and addition to the https://github.com/bazelbuild/bazel-central-registry.

This version has been added to the BCR in https://github.com/bazelbuild/bazel-central-registry/pull/38 already. The changes introduced by this PR are so that future versions will no longer [require patching](https://github.com/bazelbuild/bazel-central-registry/pull/38/files#diff-6067dfb1d9cd3806078e211bf7f4d97ce8e8722f3af151b3af162ac63217e303R5) to be added to the BCR.

Adds a module rule `sh_configure` for the POSIX toolchain configured by `sh_posix_configure`. Module rules may invoke repository rules, but may not register toolchains. This commit adds a boolean parameter `register` to `sh_posix_configure` for compatibility with both the old repository rule workflow and the new module workflow.

Adds instructions for creating new Bazel Central Registry entries to `MAINTAINERS.md`.

Extends CI configuration to test with bzlmod enabled.