### PR TITLE
Cleanup: Use Bazel version 5.1.0 to test bzlmod

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -30,9 +30,7 @@ jobs:
           EOF
           if [[ ${{ matrix.bzlmod }} == module ]]; then
             # Test with bzlmod enabled.
-            # Requires https://github.com/bazelbuild/bazel/commit/302971e1b3d803069ac949c0085c0d2a3916c8ab,
-            # see https://github.com/bazelbuild/bazel-central-registry/pull/47#issuecomment-998883652
-            echo USE_BAZEL_VERSION=302971e1b3d803069ac949c0085c0d2a3916c8ab >.bazeliskrc
+            echo USE_BAZEL_VERSION=5.1.0 >.bazeliskrc
             cat >>.bazelrc.local <<-EOF
           	build --experimental_enable_bzlmod
           	EOF


### PR DESCRIPTION
The problem reported in https://github.com/bazelbuild/bazel-central-registry/pull/47#issuecomment-998883652 should be fixed.