### PR TITLE
Implement create_shim to create a shim on Windows

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,3 +11,7 @@ sh_posix_configure()
 load("@bazel_skylib//lib:unittest.bzl", "register_unittest_toolchains")
 
 register_unittest_toolchains()
+
+load("//tests/import:import_test.bzl", "import_test_repositories")
+
+import_test_repositories()

--- a/sh/import.bzl
+++ b/sh/import.bzl
@@ -1,0 +1,70 @@
+def _copy_file(repository_ctx, *, source, destination, executable):
+    """Create a file copy of the source at the destination.
+
+    Args:
+      repository_ctx: The repository rule context.
+      source: string; Label; or path, The file to copy.
+      destination: string; Label; or path, The copy to create, relative to the repository directory.
+      executable: bool, Whether the copy should be executable.
+    """
+
+    # Note, Bazel provides no "copy file" primitive in repository rules. This
+    # reads the source file and writes a new file as a workaround.
+    # See https://github.com/bazelbuild/bazel/issues/11858
+    repository_ctx.file(
+        destination,
+        repository_ctx.read(source),
+        executable = executable,
+        legacy_utf8 = False,
+    )
+
+def create_shim(repository_ctx, *, name, target, shim_exe = Label("@rules_sh_shim_exe//file:shim.exe")):
+    """Create a binary shim for the given target.
+
+    Creates a copy of the [shim binary][shim-binary] named `<name>.exe` with a
+    neighboring `<name>.shim` file that points to the given target.
+
+    [shim-binary]: https://github.com/ScoopInstaller/Shim
+
+    #### Example
+
+    This can be used inside a repository rule run on Windows to generate a shim
+    of an external executable and import it into an `sh_binaries` target.
+
+    ```bzl
+    powershell = repository_ctx.which("powershell")
+    if powershell != None:
+        create_shim(
+            repository_ctx,
+            name = "powershell",
+            target = powershell,
+        )
+
+    repository_ctx.file(
+        "BUILD.bazel",
+        "\\n".join([
+            "sh_binaries(",
+            "    name = 'tools',",
+            "    srcs = ['powershell.exe'],",
+            "    data = ['powershell.shim'],",
+            ")",
+        ]),
+    )
+    ```
+
+    Args:
+      name: string or path, The name of the newly created shim, without the .exe suffix, relative to the repository directory.
+      target: string or path, Absolute path to the target executable.
+      shim_exe: string; Label; or path, The original shim binary.
+    """
+    _copy_file(
+        repository_ctx,
+        source = shim_exe,
+        destination = "{}.exe".format(name),
+        executable = True,
+    )
+    repository_ctx.file(
+        "{}.shim".format(name),
+        "path = {}".format(repository_ctx.path(target)),
+        executable = False,
+    )

--- a/sh/repositories.bzl
+++ b/sh/repositories.bzl
@@ -1,5 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 def rules_sh_dependencies():
     """Load repositories required by rules_sh."""
@@ -16,4 +16,12 @@ def rules_sh_dependencies():
         sha256 = "23566db029006fe23d8140d14514ada8c742d82b51973b4d331ee423c75a0bfa",
         strip_prefix = "platforms-46993efdd33b73649796c5fc5c9efb193ae19d51",
         urls = ["https://github.com/bazelbuild/platforms/archive/46993efdd33b73649796c5fc5c9efb193ae19d51.tar.gz"],
+    )
+    maybe(
+        http_file,
+        name = "rules_sh_shim_exe",
+        sha256 = "cb440b8a08a2095a59666a859b35aa5a1524b140b909ecc760f38f3baccf80e6",
+        urls = ["https://github.com/ScoopInstaller/Shim/releases/download/v1.0.1/shim.exe"],
+        downloaded_file_path = "shim.exe",
+        executable = True,
     )

--- a/tests/import/BUILD.bazel
+++ b/tests/import/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":import_test.bzl", "import_test_suite")
+
+import_test_suite(name = "import_test")

--- a/tests/import/create_shim_test.sh
+++ b/tests/import/create_shim_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+set -euo pipefail
+
+SHIM_EXE="$(rlocation "$1")"
+EMPTY_EXE="$(rlocation "$2")"
+
+SHIMMED_EXE="$(rlocation "$3")"
+SHIMMED_SHIM="$(rlocation "$4")"
+
+ANOTHER_EXE="$(rlocation "$5")"
+ANOTHER_SHIM="$(rlocation "$6")"
+
+assert_file_eq() {
+  comm "$1" "$2" || {
+    echo "Expected files to be equal, but they are different: '$1' and '$2'". >&2
+    return 1
+  }
+}
+
+# Test that the shims use the correct shim.exe.
+
+assert_file_eq "$SHIM_EXE" "$SHIMMED_EXE"
+assert_file_eq "$SHIM_EXE" "$ANOTHER_EXE"
+
+parse_shim() {
+  local line
+  read -r line <"$1" || true
+  if [[ $line =~ ^path\ \=\ (.*)$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    echo "Malformed shim file: '$1'" >&2
+    return 1
+  fi
+}
+
+# Test that the target of the shim matches the correct target file.
+
+SHIMMED_TARGET="$(parse_shim "$SHIMMED_SHIM")"
+assert_file_eq "$EMPTY_EXE" "$SHIMMED_TARGET"
+
+ANOTHER_TARGET="$(parse_shim "$ANOTHER_SHIM")"
+assert_file_eq "$EMPTY_EXE" "$ANOTHER_TARGET"

--- a/tests/import/import_test.bzl
+++ b/tests/import/import_test.bzl
@@ -1,0 +1,162 @@
+load("@bazel_tools//tools/cpp:lib_cc_configure.bzl", "get_cpu_value")
+load("@rules_sh//sh:import.bzl", "create_shim")
+
+# create shim ########################################################
+
+def _create_shim_test():
+    native.sh_test(
+        name = "create_shim_test",
+        srcs = ["create_shim_test.sh"],
+        deps = ["@bazel_tools//tools/bash/runfiles"],
+        data = [
+            "@rules_sh_shim_exe//file:shim.exe",
+            "@rules_sh_import_test_create_shim_test_source//:empty.exe",
+            "@rules_sh_import_test_create_shim_test_shim//:shimmed.exe",
+            "@rules_sh_import_test_create_shim_test_shim//:shimmed.shim",
+            "@rules_sh_import_test_create_shim_test_shim//prefix:another.exe",
+            "@rules_sh_import_test_create_shim_test_shim//prefix:another.shim",
+        ],
+        args = [
+            "rules_sh/$(rootpath @rules_sh_shim_exe//file:shim.exe)",
+            "rules_sh/$(rootpath @rules_sh_import_test_create_shim_test_source//:empty.exe)",
+            "rules_sh/$(rootpath @rules_sh_import_test_create_shim_test_shim//:shimmed.exe)",
+            "rules_sh/$(rootpath @rules_sh_import_test_create_shim_test_shim//:shimmed.shim)",
+            "rules_sh/$(rootpath @rules_sh_import_test_create_shim_test_shim//prefix:another.exe)",
+            "rules_sh/$(rootpath @rules_sh_import_test_create_shim_test_shim//prefix:another.shim)",
+        ],
+    )
+
+def _create_shim_test_source_repository_impl(repository_ctx):
+    repository_ctx.file(
+        "empty.exe",
+        "",
+        executable = True,
+    )
+    repository_ctx.file(
+        "BUILD.bazel",
+        'exports_files(["empty.exe"])',
+        executable = False,
+    )
+
+_create_shim_test_source_repository = repository_rule(
+    _create_shim_test_source_repository_impl,
+)
+
+def _create_shim_test_shim_repository_impl(repository_ctx):
+    create_shim(
+        repository_ctx,
+        name = "shimmed",
+        target = repository_ctx.attr.empty_exe,
+    )
+    create_shim(
+        repository_ctx,
+        name = "prefix/another",
+        target = repository_ctx.attr.empty_exe,
+    )
+    repository_ctx.file(
+        "BUILD.bazel",
+        'exports_files(["shimmed.exe", "shimmed.shim"])',
+        executable = False,
+    )
+    repository_ctx.file(
+        "prefix/BUILD.bazel",
+        'exports_files(["another.exe", "another.shim"])',
+        executable = False,
+    )
+
+_create_shim_test_shim_repository = repository_rule(
+    _create_shim_test_shim_repository_impl,
+    attrs = {
+        "empty_exe": attr.label(mandatory = True),
+    },
+)
+
+def _create_shim_repositories():
+    _create_shim_test_source_repository(
+        name = "rules_sh_import_test_create_shim_test_source",
+    )
+    _create_shim_test_shim_repository(
+        name = "rules_sh_import_test_create_shim_test_shim",
+        empty_exe = "@rules_sh_import_test_create_shim_test_source//:empty.exe",
+    )
+
+# invoke shim ########################################################
+
+def _invoke_shim_test():
+    native.genrule(
+        name = "invoke_shim",
+        outs = ["invoke_shim.out"],
+        cmd = """\
+PATH="$(_TOOLS_PATH):$$PATH"
+powershell -Command 'echo "Hello World" | Out-File -FilePath $(OUTS)'
+""",
+        toolchains = ["@rules_sh_import_test_invoke_shim_test_powershell//:tools"],
+        tags = ["manual"],
+        target_compatible_with = ["@platforms//os:windows"],
+    )
+    native.sh_test(
+        name = "invoke_shim_test",
+        srcs = ["invoke_shim_test.sh"],
+        deps = ["@bazel_tools//tools/bash/runfiles"],
+        data = [":invoke_shim"],
+    )
+
+def _invoke_shim_test_powershell_impl(repository_ctx):
+    cpu_value = get_cpu_value(repository_ctx)
+    if cpu_value.find("windows") != -1:
+        powershell = repository_ctx.which("powershell")
+        if powershell == None:
+            fail("Could not find powershell")
+        create_shim(
+            repository_ctx,
+            name = "powershell",
+            target = powershell,
+        )
+    repository_ctx.file(
+        "BUILD.bazel",
+        """\
+load("@rules_sh//sh:sh.bzl", "sh_binaries")
+sh_binaries(
+    name = "tools",
+    srcs = select({
+        "@platforms//os:windows": ["powershell.exe"],
+        "//conditions:default": [],
+    }),
+    data = select({
+        "@platforms//os:windows": ["powershell.shim"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+""",
+        executable = True,
+    )
+
+_invoke_shim_test_powershell = repository_rule(
+    _invoke_shim_test_powershell_impl,
+)
+
+def _invoke_shim_repositories():
+    _invoke_shim_test_powershell(
+        name = "rules_sh_import_test_invoke_shim_test_powershell",
+    )
+
+# test suite #########################################################
+
+def import_test_suite(name):
+    _create_shim_test()
+    _invoke_shim_test()
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":create_shim_test",
+            ":invoke_shim_test",
+        ],
+    )
+
+# external workspaces ################################################
+
+def import_test_repositories():
+    _create_shim_repositories()
+    _invoke_shim_repositories()

--- a/tests/import/invoke_shim_test.sh
+++ b/tests/import/invoke_shim_test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+set -euo pipefail
+
+assert_eq() {
+  if [[ "$1" != "$2" ]]; then
+    echo -e "Wrong output found in $3:\nExpected: '$1'\nGot: '$2'"
+    return 1
+  fi
+}
+
+EXPECTED_OUTPUT="Hello World"
+OUTPUT="$(cat "$(rlocation "rules_sh/tests/import/invoke_shim.out")" | tr -d '\376\377')"  # Remove BOM
+assert_eq "$EXPECTED_OUTPUT" "$OUTPUT" "invoke_shim"


### PR DESCRIPTION
Part of https://github.com/tweag/rules_sh/issues/19

The `sh_binaries` rule can bundle Bazel tracked executable `File`
objects as collections of tools. Tools can be imported into Bazel by
download or built by Bazel. However, in some use-cases, users need to
import executales that are installed outside of Bazel from the system.

On Unix systems this can be achieved in a hermetic way by creating a
symbolic link in a repository rule. However, on Windows, symbolic file
links are not generally available and the corresponding `repository_ctx`
method will create a copy. However, file copies do not generally work,
as executables may expect auxiliary files next to their installation
path.

A shim offers an alternative on Windows. A shim is a small executable,
accompanied by a small data file that points to the destination. It can
be thought of as a custom executable that imitates the functionality of
a symbolic file link.