### PR TITLE
Use stardoc to automatically generate README.md

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -33,6 +33,8 @@ jobs:
             echo USE_BAZEL_VERSION=5.1.0 >.bazeliskrc
             cat >>.bazelrc.local <<-EOF
           	build --experimental_enable_bzlmod
+          	build --build_tag_filters=-stardoc_generation
+          	test --test_tag_filters=-stardoc_generation
           	EOF
           fi
       - name: Build & Test

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -28,13 +28,21 @@ jobs:
           machine api.github.com
                   password ${{ secrets.GITHUB_TOKEN }}
           EOF
+          cat >.bazelrc.disable-stardoc <<-EOF
+          	build --build_tag_filters=-stardoc_generation
+          	test --test_tag_filters=-stardoc_generation
+          	EOF
+          if [[ ${{ runner.os }} == Windows ]]; then
+            # Stardoc complains about docstring quote indentation on Windows.
+            cat .bazelrc.disable-stardoc >>.bazelrc.local
+          fi
           if [[ ${{ matrix.bzlmod }} == module ]]; then
+            # Stardoc does not work with bzlmod.
+            cat .bazelrc.disable-stardoc >>.bazelrc.local
             # Test with bzlmod enabled.
             echo USE_BAZEL_VERSION=5.1.0 >.bazeliskrc
             cat >>.bazelrc.local <<-EOF
           	build --experimental_enable_bzlmod
-          	build --build_tag_filters=-stardoc_generation
-          	test --test_tag_filters=-stardoc_generation
           	EOF
           fi
       - name: Build & Test

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["README.md"])

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 0,
     toolchains_to_register = ["@local_posix_config//:local_posix_toolchain"],
 )
-bazel_dep(name = "bazel_skylib", version = "1.0.3")
+bazel_dep(name = "bazel_skylib", version = "1.2.1")
 bazel_dep(name = "platforms", version = "0.0.4")
 
 sh_configure = use_extension("@rules_sh//bzlmod:extensions.bzl", "sh_configure")

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ load("@rules_sh//sh:repositories.bzl", "rules_sh_dependencies")
 rules_sh_dependencies()
 ```
 
+
+
 ## Usage
 
 ### Configure the toolchain
@@ -90,3 +92,5 @@ my_rule = rule(
     ...
 )
 ```
+
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,3 +15,19 @@ register_unittest_toolchains()
 load("//tests/import:import_test.bzl", "import_test_repositories")
 
 import_test_repositories()
+
+
+# documentation dependencies
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+maybe(
+    http_archive,
+    "io_bazel_stardoc",
+    sha256 = "aa814dae0ac400bbab2e8881f9915c6f47c49664bf087c409a15f90438d2c23e",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz",
+        "https://github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz",
+    ],
+)

--- a/sh/BUILD.bazel
+++ b/sh/BUILD.bazel
@@ -22,6 +22,20 @@ bzl_library(
 )
 
 bzl_library(
+    name = "sh",
+    srcs = [
+        "sh.bzl",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bazel_tools",
+        "@bazel_skylib//lib:paths",
+        "@bazel_skylib//lib:dicts",
+        "//sh/private:defs.bzl"
+    ],
+)
+
+bzl_library(
     name = "posix",
     srcs = [
         "posix.bzl",
@@ -32,3 +46,8 @@ bzl_library(
         "@bazel_skylib//lib:paths",
     ],
 )
+
+exports_files([
+    "posix.bzl",
+    "repositories.bzl",
+])

--- a/sh/docs/BUILD.bazel
+++ b/sh/docs/BUILD.bazel
@@ -2,6 +2,12 @@ load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
+# The following rules are tagged with 'stardoc_generation' so we can skip them
+# for Github pipelines that have bzlmod enabled. This is necessary because
+# Stardoc does not currently work with modules. For more information see:
+#   https://github.com/bazelbuild/stardoc/issues/117
+#   https://github.com/bazelbuild/bazel/issues/14140
+
 stardoc(
     name = "gen-setup-md",
     input = "//sh:repositories.bzl",
@@ -10,6 +16,7 @@ stardoc(
     symbol_names = ["rules_sh_dependencies"],
     func_template = "//sh/docs:func.vm",
     header_template = "//sh/docs:header.vm",
+    tags = ["stardoc_generation"],
 )
 
 stardoc(
@@ -20,6 +27,7 @@ stardoc(
     symbol_names = ["sh_posix_configure"],
     func_template = "//sh/docs:func.vm",
     header_template = "//sh/docs:empty.vm",
+    tags = ["stardoc_generation"],
 )
 
 genrule(
@@ -28,6 +36,7 @@ genrule(
     srcs = [":setup.md", ":usage.md"],
     cmd = "$(POSIX_CAT) $(execpath :setup.md) $(execpath :usage.md) >$(OUTS)",
     toolchains = ["@rules_sh//sh/posix:make_variables"],
+    tags = ["stardoc_generation"],
 )
 
 write_file(
@@ -36,6 +45,7 @@ write_file(
     content = ["""
         "$POSIX_CP" -v --no-preserve=all "$1" "$BUILD_WORKSPACE_DIRECTORY/README.md"
     """],
+    tags = ["stardoc_generation"],
 )
 
 sh_binary(
@@ -45,6 +55,7 @@ sh_binary(
     data = [":readme.md"],
     env = {"POSIX_CP": "$(POSIX_CP)"},
     toolchains = ["@rules_sh//sh/posix:make_variables"],
+    tags = ["stardoc_generation"],
 )
 
 diff_test(
@@ -52,4 +63,5 @@ diff_test(
     failure_message = "Please run: bazel run //sh/docs:update-readme",
     file1 = "//:README.md",
     file2 = ":readme.md",
+    tags = ["stardoc_generation"],
 )

--- a/sh/docs/BUILD.bazel
+++ b/sh/docs/BUILD.bazel
@@ -1,0 +1,55 @@
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+
+stardoc(
+    name = "gen-setup-md",
+    input = "//sh:repositories.bzl",
+    out = "setup.md",
+    deps = ["//sh:repositories"],
+    symbol_names = ["rules_sh_dependencies"],
+    func_template = "//sh/docs:func.vm",
+    header_template = "//sh/docs:header.vm",
+)
+
+stardoc(
+    name = "gen-usage-md",
+    input = "//sh:posix.bzl",
+    out = "usage.md",
+    deps = ["//sh:posix"],
+    symbol_names = ["sh_posix_configure"],
+    func_template = "//sh/docs:func.vm",
+    header_template = "//sh/docs:empty.vm",
+)
+
+genrule(
+    name = "gen-readme-md",
+    outs = ["readme.md"],
+    srcs = [":setup.md", ":usage.md"],
+    cmd = "$(POSIX_CAT) $(execpath :setup.md) $(execpath :usage.md) >$(OUTS)",
+    toolchains = ["@rules_sh//sh/posix:make_variables"],
+)
+
+write_file(
+    name = "write-copy-readme-sh",
+    out = "copy-readme.sh",
+    content = ["""
+        "$POSIX_CP" -v --no-preserve=all "$1" "$BUILD_WORKSPACE_DIRECTORY/README.md"
+    """],
+)
+
+sh_binary(
+    name = "update-readme",
+    srcs = [":copy-readme.sh"],
+    args = ["$(location :readme.md)"],
+    data = [":readme.md"],
+    env = {"POSIX_CP": "$(POSIX_CP)"},
+    toolchains = ["@rules_sh//sh/posix:make_variables"],
+)
+
+diff_test(
+    name = "check-readme",
+    failure_message = "Please run: bazel run //sh/docs:update-readme",
+    file1 = "//:README.md",
+    file2 = ":readme.md",
+)

--- a/sh/docs/func.vm
+++ b/sh/docs/func.vm
@@ -1,0 +1,1 @@
+${funcInfo.docString}

--- a/sh/docs/header.vm
+++ b/sh/docs/header.vm
@@ -1,0 +1,3 @@
+# Shell rules for Bazel
+
+This project extends Bazel with a toolchain for common shell commands.

--- a/sh/private/BUILD.bazel
+++ b/sh/private/BUILD.bazel
@@ -8,3 +8,5 @@ bool_constant(
     }),
     visibility = ["//visibility:public"],
 )
+
+exports_files(["defs.bzl"])

--- a/sh/repositories.bzl
+++ b/sh/repositories.bzl
@@ -27,9 +27,11 @@ def rules_sh_dependencies():
     maybe(
         http_archive,
         name = "bazel_skylib",
-        sha256 = "710c2ca4b4d46250cdce2bf8f5aa76ea1f0cba514ab368f2988f70e864cfaf51",
-        strip_prefix = "bazel-skylib-1.2.1",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/1.2.1.tar.gz"],
+        sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+        ],
     )
     maybe(
         http_archive,

--- a/sh/repositories.bzl
+++ b/sh/repositories.bzl
@@ -2,13 +2,34 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 def rules_sh_dependencies():
-    """Load repositories required by rules_sh."""
+    """## Setup
+
+    See the **WORKSPACE setup** section of the [current release][releases].
+
+    [releases]: https://github.com/tweag/rules_sh/releases
+
+    Or use the following template in your `WORKSPACE` file to install a development
+    version of `rules_sh`:
+
+    ``` python
+    load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+    http_archive(
+        name = "rules_sh",
+        # Replace git revision and sha256.
+        sha256 = "0000000000000000000000000000000000000000000000000000000000000000",
+        strip_prefix = "rules_sh-0000000000000000000000000000000000000000",
+        urls = ["https://github.com/tweag/rules_sh/archive/0000000000000000000000000000000000000000.tar.gz"],
+    )
+    load("@rules_sh//sh:repositories.bzl", "rules_sh_dependencies")
+    rules_sh_dependencies()
+    ```
+    """
     maybe(
         http_archive,
         name = "bazel_skylib",
-        sha256 = "e5d90f0ec952883d56747b7604e2a15ee36e288bb556c3d0ed33e818a4d971f2",
-        strip_prefix = "bazel-skylib-1.0.2",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/1.0.2.tar.gz"],
+        sha256 = "710c2ca4b4d46250cdce2bf8f5aa76ea1f0cba514ab368f2988f70e864cfaf51",
+        strip_prefix = "bazel-skylib-1.2.1",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/1.2.1.tar.gz"],
     )
     maybe(
         http_archive,


### PR DESCRIPTION
This change adds targets for automatically generating `README.md` from stardoc docstrings as requested in #24.

* Verify that `README.md` is up-to-date: `bazel test //sh/docs:check-readme` 
* Update `README.md` if necessary: `bazel run //sh/docs:update-readme`

Due to a [stardoc / bzlmod issue](https://github.com/bazelbuild/stardoc/issues/117) these targets are not run for "modules" pipelines on CI. They are also disabled for Windows because it [fails to parse](https://github.com/tweag/rules_sh/runs/7994246856?check_suite_focus=true) the docstring for some reason (I'm guessing line ending differences):
```
sh\repositories.bzl:4:5 line 22: closing docstring quote should be indented the same as the opening quote
```