### PR TITLE
Add Publish to BCR templates

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,17 @@
+{
+  "homepage": "https://github.com/tweag/rules_sh#readme",
+  "maintainers": [
+    {
+      "email": "andreas.herrmann@tweag.io",
+      "github": "aherrmann",
+      "name": "Andreas Herrmann"
+    },
+    {
+      "email": "claudio.bley@tweag.io",
+      "github": "avdv",
+      "name": "Claudio Bley"
+    }
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,16 @@
+platforms:
+  centos7:
+    build_targets:
+    - '@rules_sh//...'
+  debian10:
+    build_targets:
+    - '@rules_sh//...'
+  macos:
+    build_targets:
+    - '@rules_sh//...'
+  ubuntu2004:
+    build_targets:
+    - '@rules_sh//...'
+  windows:
+    build_targets:
+    - '@rules_sh//...'

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+}


### PR DESCRIPTION
Take the [template files from the Publish to BCR project](https://github.com/bazel-contrib/publish-to-bcr/tree/main/templates), customize them, and add them to the root of project.

The `presubmit.yaml` is based on what we were already using in the BCR.

After this, creating a new release of `rules_sh`, should result in an automated commit to [our fork of the BCR](https://github.com/tweag/bazel-central-registry) and a PR from there to the BCR.

Resolves #36