### PR TITLE
Bring module up to par with BCR

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,15 +2,20 @@ platforms:
   centos7:
     build_targets:
     - '@rules_sh//...'
+    - '-@rules_sh//tests/...'
   debian10:
     build_targets:
     - '@rules_sh//...'
+    - '-@rules_sh//tests/...'
   macos:
     build_targets:
     - '@rules_sh//...'
+    - '-@rules_sh//tests/...'
   ubuntu2004:
     build_targets:
     - '@rules_sh//...'
+    - '-@rules_sh//tests/...'
   windows:
     build_targets:
     - '@rules_sh//...'
+    - '-@rules_sh//tests/...'

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,11 +1,13 @@
 module(
     name = "rules_sh",
-    version = "0.2.0",
+    version = "0.3.0",
     compatibility_level = 0,
-    toolchains_to_register = ["@local_posix_config//:local_posix_toolchain"],
 )
 bazel_dep(name = "bazel_skylib", version = "1.2.1")
 bazel_dep(name = "platforms", version = "0.0.5")
 
-sh_configure = use_extension("@rules_sh//bzlmod:extensions.bzl", "sh_configure")
-use_repo(sh_configure, "local_posix_config")
+sh_configure = use_extension("//bzlmod:extensions.bzl", "sh_configure")
+
+use_repo(sh_configure, "local_posix_config", "rules_sh_shim_exe")
+
+register_toolchains("@local_posix_config//:local_posix_toolchain")

--- a/bzlmod/extensions.bzl
+++ b/bzlmod/extensions.bzl
@@ -1,6 +1,14 @@
 load("//sh:posix.bzl", "sh_posix_configure")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def _sh_configure_impl(ctx):
     sh_posix_configure(register = False)
+    http_file(
+        name = "rules_sh_shim_exe",
+        sha256 = "cb440b8a08a2095a59666a859b35aa5a1524b140b909ecc760f38f3baccf80e6",
+        urls = ["https://github.com/ScoopInstaller/Shim/releases/download/v1.0.1/shim.exe"],
+        downloaded_file_path = "shim.exe",
+        executable = True,
+    )
 
 sh_configure = module_extension(implementation = _sh_configure_impl)


### PR DESCRIPTION
Version 0.3.0 currently requires a [patch](https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/rules_sh/0.3.0/patches/fix-version.patch) in the central registry. This PR should make this patch obsolete.

* update version in `MODULE.bazel` to match the current release
* use `register_toolchain` instead of `module.toolchains_to_register`
* add `rules_sh_shim_exe` repository in the bzlmod extension
* use `local_posix_config` and `rules_sh_shim_exe` repositories
* update `presubmit.yml` file to match the one in the BCR

See https://github.com/bazelbuild/bazel-central-registry/pull/151