### PR TITLE
Allow disabling the toolchain `sh_configure` creates under bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,4 +11,4 @@ sh_configure = use_extension("//bzlmod:extensions.bzl", "sh_configure")
 
 use_repo(sh_configure, "local_posix_config", "rules_sh_shim_exe")
 
-register_toolchains("@local_posix_config//:local_posix_toolchain")
+register_toolchains("@local_posix_config//...")

--- a/bzlmod/extensions.bzl
+++ b/bzlmod/extensions.bzl
@@ -1,8 +1,66 @@
 load("//sh:posix.bzl", "sh_posix_configure")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
-def _sh_configure_impl(ctx):
-    sh_posix_configure(register = False)
+def _get_local_posix_config_enabled(module_ctx):
+    # Check that every `local_posix_config` tag on this extension agrees about
+    # whether we should create the local posix toolchain:
+    #
+    # (if no tags are set, default to true)
+    enable_attrs = [
+        tag.enable
+        for mod in module_ctx.modules
+        for tag in mod.tags.local_posix_config
+    ] or [True]
+
+    if all(enable_attrs) or not any(enable_attrs):
+        return enable_attrs[0]
+    else:
+        # if the tags are not in agreement:
+        msg = "Mismatched values for `sh_configure.local_posix_config.enable`:"
+
+        for mod in module_ctx.modules:
+            msg += "\n  - module `{}` (version: {}) specifies:".format(
+                mod.name, mod.version,
+            )
+            for tag in mod.tags.local_posix_config:
+                msg += "\n    * {}".format(tag.enable)
+        msg += "\n"
+
+        # fallback to using the first occurrence:
+        (fallback, mod_name, mod_version) = [
+            (tag.enable, mod.name, mod.version)
+            for mod in module_ctx.modules
+            for tag in mod.tags.local_posix_config
+        ][0]
+
+        msg += "\nUsing `{}` from module `{}` (version: {}) ".format(
+            fallback, mod_name, mod_version,
+        )
+        msg += "— this is the first occurrence of this tag reached via BFS from "
+        msg += "the root module."
+
+        print(msg)
+        return fallback
+
+# Note: inlining this makes Bazel crash with:
+# ```
+# net.starlark.java.eval.Starlark$UncheckedEvalException:
+#   IllegalStateException thrown during Starlark evaluation
+# ```
+_stub = repository_rule(
+    implementation = lambda rctx: rctx.file("BUILD.bazel"),
+)
+
+def _sh_configure_impl(module_ctx):
+    enable_local_posix_toolchain = _get_local_posix_config_enabled(module_ctx)
+
+    if enable_local_posix_toolchain:
+        sh_posix_configure(register = False)
+    else:
+        # stub repository so `use_repo(..., "local_posix_config")` and
+        # `register_toolchains("@local_posix_config//...")` do not raise errors
+        _stub(name = "local_posix_config")
+
     http_file(
         name = "rules_sh_shim_exe",
         sha256 = "cb440b8a08a2095a59666a859b35aa5a1524b140b909ecc760f38f3baccf80e6",
@@ -11,4 +69,33 @@ def _sh_configure_impl(ctx):
         executable = True,
     )
 
-sh_configure = module_extension(implementation = _sh_configure_impl)
+sh_configure = module_extension(
+    implementation = _sh_configure_impl,
+    tag_classes = {
+        "local_posix_config": tag_class(
+            attrs = {
+                "enable": attr.bool(
+                    default = True,
+                    doc = """
+Whether to create and register the `@local_posix_config//:local_posix_toolchain`
+toolchain.
+
+In the event that there are multiple instances of this tag that contradict, the
+first tag's value (where modules are ordered by BFS from the root module) will
+be used.
+""",
+                ),
+            },
+            doc = """
+Tag class with options for the `@local_posix_config` repo that this extension
+creates.
+""",
+        ),
+    },
+    doc = """
+Module extension that sets up `rules_sh` toolchains.
+
+This is essentially a wrapper over `@rules_sh//sh:posix.bzl#sh_posix_configure`
+for use with bzlmod.
+""",
+)


### PR DESCRIPTION
## Motivation

I have a use case where I want to register my own posix toolchain and don't want Bazel to fall back to using the `local_posix` toolchain (the toolchain I'm making has certain constraints — when they aren't met I want Bazel to error).

`sh_posix_configure` provides an easy way to skip registering the local toolchain at `@local_posix_config//:local_posix_toolchain` but using `rules_sh` via bzlmod does not expose a way to configure this:

https://github.com/tweag/rules_sh/blob/0e3d91d962ebbbc2425a6414d0052ff43d853149/MODULE.bazel#L14

## A Solution

While we can condition the `register_toolchains` invocation [^1] in `MODULE.bazel` (i.e. `register_toolchains(...) if <condition> else None` is permitted), unfortunately, as far as I know, there isn't a way to read data from module extension tag classes within `MODULE.bazel`.

This PR instead has the `sh_configure` module extension conditionally generate the `@local_posix_config//:local_posix_toolchain` toolchain and alters `MODULE.bazel` to register `@local_posix_config//...` (empty when the toolchain isn't created).

[^1]: additionally, [only `register_toolchains` invocations from within `MODULE.bazel` files](https://bazel.build/external/migration#register-toolchains) are honored

---

This PR adds a `local_posix_config` tag class to `sh_configure`. This allows users to add snippets like this to their `MODULE.bazel` file to configure whether the local posix toolchain is generated and registered:

```starlark
sh_configure = use_extension("@rules_sh//bzlmod:extensions.bzl", "sh_configure")
sh_configure.local_posix_config(enable = False)
```

If no tags are specified, the toolchain is generated (making this is a backwards compatible change).

If multiple tags are specified with different values for `enable`, the extension emits a warning and takes the first value in `module_ctx.modules` (i.e. first tag of the first module reached via BFS from the root module):
```
DEBUG: /build/.cache/bazel/_bazel/fd74e05c5349be765d3f152fca12c623/external/rules_sh~override/bzlmod/extensions.bzl:41:14: Mismatched values for `sh_configure.local_posix_config.enable`:
  - module `bzlmod_test` (version: 0.0.1) specifies:
    * True
    * False
  - module `rules_sh` (version: 0.3.0) specifies:
    * False

Using `True` from `bzlmod_test` (version: 0.0.1) — this is the first module specifying this tag that's reached via BFS from the root module.
```

## Open Questions/Notes
  - [ ] Is the asymmetry with `sh_posix_configure` okay? (i.e. gating the creation of the toolchain instead of just its registration)
    + if we wish to gate only the _registration_ of `@local_posix_config//:local_posix_toolchain` and not its creation, we can add another level of indirection: a wrapper repo that `sh_configure` emits that can (conditionally) re-export the toolchain
  - [ ] I've added docstrings for the module extension, the tag class, and the attr on the tag class; I believe recent version of stardoc will pick up these docs (but I have not upgraded stardoc in the workspace or wired up generating docs for `extensions.bzl` in this PR — I can update this PR with those changes if desired)
  - I've tested these changes locally but have not added tests to the repo for this (afaict this would require adding some extra test workspaces...)