### PR TITLE
Run CI workflow for PRs too

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,5 +1,10 @@
 name: Continuous integration
-on: [push]
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+  workflow_dispatch: # allows manual triggering
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,8 +33,14 @@ jobs:
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
+          if [ -z "$BUILDBUDDY_API_KEY" ]; then
+              cache_setting='--noremote_upload_local_results'
+          else
+              cache_setting="--remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
+          fi
+
           cat >.bazelrc.local <<EOF
-          build:ci --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
+          build $cache_setting
           build --config=ci
           EOF
           cat >~/.netrc <<EOF

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
         bazel_mode: [workspace, module]
         version: ["5.3.0", "6.0.0"]
         exclude:


### PR DESCRIPTION
Currently, the CI workflow is triggered when pushing to this repository.

We should also trigger the workflow for PRs contributed from somebody else.