### PR TITLE
Mark `stardoc` as a dev dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 bazel_dep(name = "bazel_skylib", version = "1.2.1")
 bazel_dep(name = "platforms", version = "0.0.5")
-bazel_dep(name = "stardoc", version = "0.5.1", repo_name = "io_bazel_stardoc")
+bazel_dep(name = "stardoc", version = "0.5.1", repo_name = "io_bazel_stardoc", dev_dependency = True)
 
 sh_configure = use_extension("//bzlmod:extensions.bzl", "sh_configure")
 


### PR DESCRIPTION
This reduces the number of transitive deps that are pulled into modules that depend on `rules_sh`.

I couldn't find it in the changelog but as far as I can tell the `dev_dependency` option on `bazel_dep` [was added in 5.0](https://github.com/bazelbuild/bazel/commit/e83858bca9112e70f60b56fa70dcc01d42e4fa03) so I don't think this is a breaking change.

---

I haven't added [`--ignore_dev_dependency`](https://bazel.build/reference/command-line-reference#flag--ignore_dev_dependency) to CI to ensure that the tests pass without the `stardoc` dep but I can update this PR to do so if that's appropriate.