### PR TITLE
chore: rename cache config group to remote-cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,16 +1,16 @@
 # Remote Cache Configuration
-build:cache --bes_results_url=https://app.buildbuddy.io/invocation/
-build:cache --bes_backend=grpcs://remote.buildbuddy.io
-build:cache --remote_cache=grpcs://remote.buildbuddy.io
-build:cache --remote_timeout=3600
+build:remote-cache --bes_results_url=https://app.buildbuddy.io/invocation/
+build:remote-cache --bes_backend=grpcs://remote.buildbuddy.io
+build:remote-cache --remote_cache=grpcs://remote.buildbuddy.io
+build:remote-cache --remote_timeout=3600
 # Avoid failures of the form `deadline exceeded after 14999958197ns DEADLINE_EXCEEDED`.
 # See https://github.com/tweag/rules_haskell/issues/1498.
-build:cache --keep_backend_build_event_connections_alive=false
+build:remote-cache --keep_backend_build_event_connections_alive=false
 # All clients except CI should be configured as read-only
-build:cache --noremote_upload_local_results
+build:remote-cache --noremote_upload_local_results
 
 # CI Configuration
-build:ci --config=cache
+build:ci --config=remote-cache
 build:ci --remote_upload_local_results
 test:ci --test_output=errors
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,11 +38,11 @@ Read how to [set up your development environment](https://bazel.build/contributi
 ## Bazel Remote Cache
 
 The remote cache configuration for this repository is stored in [.bazelrc](/.bazelrc) and grouped
-under the name, `cache`. It is configured to allow read-only access for all clients and read-write
-for CI. 
+under the name, `remote-cache`. It is configured to allow read-only access for all clients and
+read-write for CI. 
 
 To enable the remote cache, 
 
 1. Add `build --remote_header=x-buildbuddy-api-key=${buildbuddy_api_key}` to `.bazelrc.auth`
    at the root of the workspace, replacing `${buildbuddy_api_key}` with the actual API key value.
-1. Add `build --config=cache` to `.bazelrc.local` at the root of the workspace.
+1. Add `build --config=remote-cache` to `.bazelrc.local` at the root of the workspace.


### PR DESCRIPTION
Other repositories were already using the config name `remote-cache`.  Given that Bazel has many caches, this is a better name.

Related to https://github.com/tweag/scalable-builds-group/issues/107.