### PR TITLE
chore: refactor bazel test execution to a GitHub action

### DIFF
--- a/.github/actions/run_bazel_test/action.yaml
+++ b/.github/actions/run_bazel_test/action.yaml
@@ -4,40 +4,10 @@ description: Handles platform-specific settings.
 inputs:
   working-directory:
     type: string
-  # TODO: REMOVE os input
-  os:
-    type: string
 
 runs:
   using: composite
   steps:
-    # - shell: bash
-    #   env:
-    #     BAZEL_SH: ${{ startswith(inputs.os, 'windows-') && 'C:\msys64\usr\bin\bash.exe' || '' }}
-    #     RBT_WORKING_DIR: ${{ inputs.working-directory }}
-    #   run: |
-    #     [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
-    #     bazel test "//..."
-    # - shell: bash
-    #   if: ${{ startswith(inputs.os, 'windows-') }}
-    #   env:
-    #     BAZEL_SH: 'C:\msys64\usr\bin\bash.exe' 
-    #     RBT_WORKING_DIR: ${{ inputs.working-directory }}
-    #   run: |
-    #     [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
-    #     # DEBUG BEGIN
-    #     set -x
-    #     uname_output="$( uname -a )"
-    #     echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") uname_output: ${uname_output}" 
-    #     # DEBUG END
-    #     bazel test '//...'
-    # - shell: bash
-    #   if: ${{ ! startswith(inputs.os, 'windows-') }}
-    #   env:
-    #     RBT_WORKING_DIR: ${{ inputs.working-directory }}
-    #   run: |
-    #     [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
-    #     bazel test '//...'
     - shell: bash
       env:
         RBT_WORKING_DIR: ${{ inputs.working-directory }}

--- a/.github/actions/run_bazel_test/action.yaml
+++ b/.github/actions/run_bazel_test/action.yaml
@@ -4,6 +4,7 @@ description: Handles platform-specific settings.
 inputs:
   working-directory:
     type: string
+  # TODO: REMOVE os input
   os:
     type: string
 
@@ -17,24 +18,27 @@ runs:
     #   run: |
     #     [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
     #     bazel test "//..."
+    # - shell: bash
+    #   if: ${{ startswith(inputs.os, 'windows-') }}
+    #   env:
+    #     BAZEL_SH: 'C:\msys64\usr\bin\bash.exe' 
+    #     RBT_WORKING_DIR: ${{ inputs.working-directory }}
+    #   run: |
+    #     [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
+    #     # DEBUG BEGIN
+    #     set -x
+    #     uname_output="$( uname -a )"
+    #     echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") uname_output: ${uname_output}" 
+    #     # DEBUG END
+    #     bazel test '//...'
+    # - shell: bash
+    #   if: ${{ ! startswith(inputs.os, 'windows-') }}
+    #   env:
+    #     RBT_WORKING_DIR: ${{ inputs.working-directory }}
+    #   run: |
+    #     [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
+    #     bazel test '//...'
     - shell: bash
-      if: ${{ startswith(inputs.os, 'windows-') }}
-      env:
-        BAZEL_SH: 'C:\msys64\usr\bin\bash.exe' 
-        RBT_WORKING_DIR: ${{ inputs.working-directory }}
-      run: |
-        [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
-        # DEBUG BEGIN
-        set -x
-        uname_output="$( uname -a )"
-        echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") uname_output: ${uname_output}" 
-        # DEBUG END
-        bazel test '//...'
-    - shell: bash
-      if: ${{ ! startswith(inputs.os, 'windows-') }}
       env:
         RBT_WORKING_DIR: ${{ inputs.working-directory }}
-      run: |
-        [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
-        bazel test '//...'
-
+      run: ${GITHUB_ACTION_PATH}/run_bazel_test.sh

--- a/.github/actions/run_bazel_test/action.yaml
+++ b/.github/actions/run_bazel_test/action.yaml
@@ -9,11 +9,11 @@ inputs:
 
 runs:
   using: composite
-  env:
-    BAZEL_SH: ${{ startswith(inputs.os, 'windows-') && 'C:\msys64\usr\bin\bash.exe' || '' }}
-    RBT_WORKING_DIR: ${{ inputs.working-directory }}
   steps:
     - shell: bash
+      env:
+        BAZEL_SH: ${{ startswith(inputs.os, 'windows-') && 'C:\msys64\usr\bin\bash.exe' || '' }}
+        RBT_WORKING_DIR: ${{ inputs.working-directory }}
       run: |
         [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
         bazel test "//..."

--- a/.github/actions/run_bazel_test/action.yaml
+++ b/.github/actions/run_bazel_test/action.yaml
@@ -10,9 +10,24 @@ inputs:
 runs:
   using: composite
   steps:
+    # - shell: bash
+    #   env:
+    #     BAZEL_SH: ${{ startswith(inputs.os, 'windows-') && 'C:\msys64\usr\bin\bash.exe' || '' }}
+    #     RBT_WORKING_DIR: ${{ inputs.working-directory }}
+    #   run: |
+    #     [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
+    #     bazel test "//..."
     - shell: bash
+      if: ${{ startswith(inputs.os, 'windows-') }}
       env:
-        BAZEL_SH: ${{ startswith(inputs.os, 'windows-') && 'C:\msys64\usr\bin\bash.exe' || '' }}
+        BAZEL_SH: 'C:\msys64\usr\bin\bash.exe' 
+        RBT_WORKING_DIR: ${{ inputs.working-directory }}
+      run: |
+        [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
+        bazel test "//..."
+    - shell: bash
+      if: ${{ ! startswith(inputs.os, 'windows-') }}
+      env:
         RBT_WORKING_DIR: ${{ inputs.working-directory }}
       run: |
         [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"

--- a/.github/actions/run_bazel_test/action.yaml
+++ b/.github/actions/run_bazel_test/action.yaml
@@ -1,0 +1,18 @@
+name: Execute Bazel test
+description: Handles platform-specific settings.
+
+inputs:
+  working-directory:
+    type: string
+
+runs:
+  using: composite
+  env:
+    BAZEL_SH: ${{ runner.os == 'Windows' && 'C:\msys64\usr\bin\bash.exe' || '' }}
+    RBT_WORKING_DIR: ${{ inputs.working-directory }}
+  steps:
+    - shell: bash
+      run: |
+        [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
+        bazel test "//..."
+

--- a/.github/actions/run_bazel_test/action.yaml
+++ b/.github/actions/run_bazel_test/action.yaml
@@ -26,6 +26,8 @@ runs:
         [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
         # DEBUG BEGIN
         set -x
+        uname_output="$( uname -a )"
+        echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") uname_output: ${uname_output}" 
         # DEBUG END
         bazel test '//...'
     - shell: bash

--- a/.github/actions/run_bazel_test/action.yaml
+++ b/.github/actions/run_bazel_test/action.yaml
@@ -24,6 +24,9 @@ runs:
         RBT_WORKING_DIR: ${{ inputs.working-directory }}
       run: |
         [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
+        # DEBUG BEGIN
+        set -x
+        # DEBUG END
         bazel test '//...'
     - shell: bash
       if: ${{ ! startswith(inputs.os, 'windows-') }}

--- a/.github/actions/run_bazel_test/action.yaml
+++ b/.github/actions/run_bazel_test/action.yaml
@@ -24,12 +24,12 @@ runs:
         RBT_WORKING_DIR: ${{ inputs.working-directory }}
       run: |
         [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
-        bazel test "//..."
+        bazel test '//...'
     - shell: bash
       if: ${{ ! startswith(inputs.os, 'windows-') }}
       env:
         RBT_WORKING_DIR: ${{ inputs.working-directory }}
       run: |
         [[ "${RBT_WORKING_DIR:-}" != "" ]] && cd "${RBT_WORKING_DIR}"
-        bazel test "//..."
+        bazel test '//...'
 

--- a/.github/actions/run_bazel_test/action.yaml
+++ b/.github/actions/run_bazel_test/action.yaml
@@ -4,11 +4,13 @@ description: Handles platform-specific settings.
 inputs:
   working-directory:
     type: string
+  os:
+    type: string
 
 runs:
   using: composite
   env:
-    BAZEL_SH: ${{ runner.os == 'Windows' && 'C:\msys64\usr\bin\bash.exe' || '' }}
+    BAZEL_SH: ${{ startswith(inputs.os, 'windows-') && 'C:\msys64\usr\bin\bash.exe' || '' }}
     RBT_WORKING_DIR: ${{ inputs.working-directory }}
   steps:
     - shell: bash

--- a/.github/actions/run_bazel_test/run_bazel_test.sh
+++ b/.github/actions/run_bazel_test/run_bazel_test.sh
@@ -23,7 +23,9 @@ if [[ "${working_dir:-}" != "" ]]; then
 fi
 
 # DEBUG BEGIN
-set -x
+echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") =============" 
+echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") PWD: ${PWD}" 
+find . -type d >&2
 # DEBUG END
 
 bazel test "${bzl_pkgs}"

--- a/.github/actions/run_bazel_test/run_bazel_test.sh
+++ b/.github/actions/run_bazel_test/run_bazel_test.sh
@@ -13,10 +13,17 @@ working_dir="${RBT_WORKING_DIR:-}"
 
 if is_windows; then
   export BAZEL_SH='C:\msys64\usr\bin\bash.exe'
+  bzl_pkgs='///...'
+else
+  bzl_pkgs='//...'
 fi
 
 if [[ "${working_dir:-}" != "" ]]; then
   cd "${working_dir}"
 fi
 
-bazel test '//...'
+# DEBUG BEGIN
+set -x
+# DEBUG END
+
+bazel test "${bzl_pkgs}"

--- a/.github/actions/run_bazel_test/run_bazel_test.sh
+++ b/.github/actions/run_bazel_test/run_bazel_test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+is_windows() {
+  local os_name
+  os_name="$( uname )"
+  # Examples: MINGW64_NT-10.0-17763
+  [[ "${os_name}" =~ ^MING ]]
+}
+
+working_dir="${RBT_WORKING_DIR:-}"
+
+if is_windows; then
+  export BAZEL_SH='C:\msys64\usr\bin\bash.exe'
+fi
+
+if [[ "${working_dir:-}" != "" ]]; then
+  cd "${working_dir}"
+fi
+
+bazel test '//...'

--- a/.github/actions/run_bazel_test/run_bazel_test.sh
+++ b/.github/actions/run_bazel_test/run_bazel_test.sh
@@ -18,7 +18,7 @@ else
   bzl_pkgs='//...'
 fi
 
-if [[ "${working_dir:-}" != "" ]]; then
+if [[ -n "${working_dir:-}" ]]; then
   cd "${working_dir}"
 fi
 

--- a/.github/actions/run_bazel_test/run_bazel_test.sh
+++ b/.github/actions/run_bazel_test/run_bazel_test.sh
@@ -22,10 +22,4 @@ if [[ "${working_dir:-}" != "" ]]; then
   cd "${working_dir}"
 fi
 
-# DEBUG BEGIN
-echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") =============" 
-echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") PWD: ${PWD}" 
-find . -type d >&2
-# DEBUG END
-
 bazel test "${bzl_pkgs}"

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -55,34 +55,46 @@ jobs:
         if: ${{ matrix.bazel_mode == 'module' }}
         with:
           content: build --experimental_enable_bzlmod
-      - name: Run tests (bzlmod)
-        if: matrix.bazel_mode == 'module'
-        working-directory: ./tests
-        run: |
-          echo "USE_BAZEL_VERSION=${{ matrix.version }}" > .bazeliskrc
-
-          if [[ ${{ runner.os }} == Windows ]]; then
-            # On Windows `//...` expands to `/...`.
-            BAZEL_SH='C:\msys64\usr\bin\bash.exe' bazel test  ///...
-          else
-            bazel test  //...
-          fi
-
-      - name: Run tests (workspace)
-        if: matrix.bazel_mode == 'workspace'
+      - name: Configure the Bazel version
         run: |
           echo "USE_BAZEL_VERSION=${{ matrix.version }}" > .bazeliskrc
           echo "USE_BAZEL_VERSION=${{ matrix.version }}" > tests/.bazeliskrc
+      - name: Run Bazel test at root
+        if: ${{ matrix.bazel_mode == 'workspace' }}
+        uses: ./.github/actions/run_bazel_test
+      - name: Run Bazel test under tests directory
+        uses: ./.github/actions/run_bazel_test
+        with:
+          working-directory: tests
 
-          if [[ ${{ runner.os }} == Windows ]]; then
-            # Because of the docstring quote issue on Windows we skip the stardoc test on the main workspace.
-            # On Windows `//...` expands to `/...`.
-            cd tests && BAZEL_SH='C:\msys64\usr\bin\bash.exe' bazel test ///...
-          else
-            bazel test //...
+      # - name: Run tests (bzlmod)
+      #   if: matrix.bazel_mode == 'module'
+      #   working-directory: ./tests
+      #   run: |
+      #     echo "USE_BAZEL_VERSION=${{ matrix.version }}" > .bazeliskrc
 
-            cd tests && bazel test //...
-          fi
+      #     if [[ ${{ runner.os }} == Windows ]]; then
+      #       # On Windows `//...` expands to `/...`.
+      #       BAZEL_SH='C:\msys64\usr\bin\bash.exe' bazel test  ///...
+      #     else
+      #       bazel test  //...
+      #     fi
+
+      # - name: Run tests (workspace)
+      #   if: matrix.bazel_mode == 'workspace'
+      #   run: |
+      #     echo "USE_BAZEL_VERSION=${{ matrix.version }}" > .bazeliskrc
+      #     echo "USE_BAZEL_VERSION=${{ matrix.version }}" > tests/.bazeliskrc
+
+      #     if [[ ${{ runner.os }} == Windows ]]; then
+      #       # Because of the docstring quote issue on Windows we skip the stardoc test on the main workspace.
+      #       # On Windows `//...` expands to `/...`.
+      #       cd tests && BAZEL_SH='C:\msys64\usr\bin\bash.exe' bazel test ///...
+      #     else
+      #       bazel test //...
+
+      #       cd tests && bazel test //...
+      #     fi
 
   all_ci_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Disable stardoc
         # Windows: Stardoc complains about docstring quote indentation on Windows.
         # bzlmod: Stardoc does not work with bzlmod.
-        if: ${{ runner.os == 'Windows' || matrix.bazel_mode == 'module' }}
+        if: ${{ matrix.os == windows-2019 || matrix.bazel_mode == 'module' }}
         uses: tweag/write-bazelrc@v0
         with:
           content: build --config=no-stardoc

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -62,13 +62,10 @@ jobs:
       - name: Run Bazel test at root
         if: ${{ matrix.bazel_mode == 'workspace' }}
         uses: ./.github/actions/run_bazel_test
-        with:
-          os: ${{ matrix.os }}
       - name: Run Bazel test under tests directory
         uses: ./.github/actions/run_bazel_test
         with:
           working-directory: tests
-          os: ${{ matrix.os }}
 
       # - name: Run tests (bzlmod)
       #   if: matrix.bazel_mode == 'module'

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -60,7 +60,7 @@ jobs:
           echo "USE_BAZEL_VERSION=${{ matrix.version }}" > .bazeliskrc
           echo "USE_BAZEL_VERSION=${{ matrix.version }}" > tests/.bazeliskrc
       - name: Run Bazel test at root
-        if: ${{ matrix.bazel_mode == 'workspace' }}
+        if: ${{ matrix.bazel_mode == 'workspace' && matrix.os != 'windows-2019' }}
         uses: ./.github/actions/run_bazel_test
       - name: Run Bazel test under tests directory
         uses: ./.github/actions/run_bazel_test

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Disable stardoc
         # Windows: Stardoc complains about docstring quote indentation on Windows.
         # bzlmod: Stardoc does not work with bzlmod.
-        if: ${{ matrix.os == windows-2019 || matrix.bazel_mode == 'module' }}
+        if: ${{ matrix.os == 'windows-2019' || matrix.bazel_mode == 'module' }}
         uses: tweag/write-bazelrc@v0
         with:
           content: build --config=no-stardoc

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -59,42 +59,13 @@ jobs:
         run: |
           echo "USE_BAZEL_VERSION=${{ matrix.version }}" > .bazeliskrc
           echo "USE_BAZEL_VERSION=${{ matrix.version }}" > tests/.bazeliskrc
-      - name: Run Bazel test at root
+      - name: Run Bazel test at the root
         if: ${{ matrix.bazel_mode == 'workspace' && matrix.os != 'windows-2019' }}
         uses: ./.github/actions/run_bazel_test
-      - name: Run Bazel test under tests directory
+      - name: Run Bazel test under the tests directory
         uses: ./.github/actions/run_bazel_test
         with:
           working-directory: tests
-
-      # - name: Run tests (bzlmod)
-      #   if: matrix.bazel_mode == 'module'
-      #   working-directory: ./tests
-      #   run: |
-      #     echo "USE_BAZEL_VERSION=${{ matrix.version }}" > .bazeliskrc
-
-      #     if [[ ${{ runner.os }} == Windows ]]; then
-      #       # On Windows `//...` expands to `/...`.
-      #       BAZEL_SH='C:\msys64\usr\bin\bash.exe' bazel test  ///...
-      #     else
-      #       bazel test  //...
-      #     fi
-
-      # - name: Run tests (workspace)
-      #   if: matrix.bazel_mode == 'workspace'
-      #   run: |
-      #     echo "USE_BAZEL_VERSION=${{ matrix.version }}" > .bazeliskrc
-      #     echo "USE_BAZEL_VERSION=${{ matrix.version }}" > tests/.bazeliskrc
-
-      #     if [[ ${{ runner.os }} == Windows ]]; then
-      #       # Because of the docstring quote issue on Windows we skip the stardoc test on the main workspace.
-      #       # On Windows `//...` expands to `/...`.
-      #       cd tests && BAZEL_SH='C:\msys64\usr\bin\bash.exe' bazel test ///...
-      #     else
-      #       bazel test //...
-
-      #       cd tests && bazel test //...
-      #     fi
 
   all_ci_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -62,10 +62,13 @@ jobs:
       - name: Run Bazel test at root
         if: ${{ matrix.bazel_mode == 'workspace' }}
         uses: ./.github/actions/run_bazel_test
+        with:
+          os: ${{ matrix.os }}
       - name: Run Bazel test under tests directory
         uses: ./.github/actions/run_bazel_test
         with:
           working-directory: tests
+          os: ${{ matrix.os }}
 
       # - name: Run tests (bzlmod)
       #   if: matrix.bazel_mode == 'module'


### PR DESCRIPTION
Create a GitHub action to execute `bazel test //...`. It supports running in a specific working directory. It also supports executing on Windows, Linux and MacOS.