### PR TITLE
Prepare release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `sh_binaries`.
   See [PR #34][#34].
 
+- Add support for Bazel 6 and 7
+  See [PR #35][#35] & [PR #43][#43].
+
+- Allow disabling the local posix toolchain under bzlmod
+  See [PR #50][#50]
+
+### Changed
+
+- Mark stardoc as a dev_dependency
+  See [PR #52][#52]
+
 [#34]: https://github.com/tweag/rules_sh/issues/34
+[#35]: https://github.com/tweag/rules_sh/issues/35
+[#43]: https://github.com/tweag/rules_sh/issues/43
+[#50]: https://github.com/tweag/rules_sh/issues/50
+[#52]: https://github.com/tweag/rules_sh/issues/52
 
 ## [0.3.0] - 2022-07-19
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_sh",
-    version = "0.3.0",
+    version = "0.4.0",
     compatibility_level = 0,
 )
 

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -1,6 +1,6 @@
 module(name = "rules_sh_tests")
 
-bazel_dep(name = "rules_sh", version = "0.3.0")
+bazel_dep(name = "rules_sh", version = "0.4.0")
 local_path_override(
     module_name = "rules_sh",
     path = "..",


### PR DESCRIPTION
A new release is in order since version 0.3.0 that is currently published to the BCR is not compatible with Bazel 7, as it is failing on amd64 Darwin with:
```
(07:18:17) INFO: ToolchainResolution: Performing resolution of @@rules_sh~0.3.0//sh/posix:toolchain_type for target platform @@local_config_platform//:host
      ToolchainResolution:   Toolchain @@rules_sh~0.3.0~sh_configure~local_posix_config//:local_posix is compatible with target plaform, searching for execution platforms:
      ToolchainResolution:     Incompatible execution platform @@local_config_platform//:host; mismatching values: linux
      ToolchainResolution: No @@rules_sh~0.3.0//sh/posix:toolchain_type toolchain found for target platform @@local_config_platform//:host.
(07:18:17) INFO: ToolchainResolution: Performing resolution of @@rules_sh~0.3.0//sh/posix:toolchain_type for target platform @@local_config_platform//:host
      ToolchainResolution:   Toolchain @@rules_sh~0.3.0~sh_configure~local_posix_config//:local_posix is compatible with target plaform, searching for execution platforms:
      ToolchainResolution:     Incompatible execution platform @@local_config_platform//:host; mismatching values: linux
      ToolchainResolution: No @@rules_sh~0.3.0//sh/posix:toolchain_type toolchain found for target platform @@local_config_platform//:host.
```

This is caused by an unexpected os value, which is gets mapped to `linux`.