### PR TITLE
Sync presubmit.yml file from BCR

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,21 +1,16 @@
-platforms:
-  centos7:
-    build_targets:
-    - '@rules_sh//...'
-    - '-@rules_sh//tests/...'
-  debian10:
-    build_targets:
-    - '@rules_sh//...'
-    - '-@rules_sh//tests/...'
-  macos:
-    build_targets:
-    - '@rules_sh//...'
-    - '-@rules_sh//tests/...'
-  ubuntu2004:
-    build_targets:
-    - '@rules_sh//...'
-    - '-@rules_sh//tests/...'
-  windows:
-    build_targets:
-    - '@rules_sh//...'
-    - '-@rules_sh//tests/...'
+bcr_test_module:
+  module_path: tests
+  matrix:
+    platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+    - windows
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      test_targets:
+      - //...
+


### PR DESCRIPTION
This PR syncs back the `presubmit.yml` file from https://github.com/bazelbuild/bazel-central-registry/pull/1228 so for the next release the Publish to BCR PR is readily prepared.