### PR TITLE
CI: Remove bazelbuild/setup-bazelisk step

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -39,7 +39,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: bazelbuild/setup-bazelisk@v2
       - uses: tweag/configure-bazel-remote-cache-auth@v0
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}


### PR DESCRIPTION
bazelisk is provided by Github's runner image by default, and the action is deprecated and has been
superseded by [setup-bazel].

[setup-bazel]: https://github.com/bazel-contrib/setup-bazel

closes #77, closes #80