### PR TITLE
Fix renovate configuration error

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,5 @@
         "github>tweag/renovate-presets:ruleset_base",
         "github>tweag/renovate-presets:mergify"
     ],
-    "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
-    "platform": "github"
+    "gitAuthor": "Renovate Bot <bot@renovateapp.com>"
 }


### PR DESCRIPTION
Repository problems

These problems occurred while renovating this repository.

    Found renovate config warnings

```
The "platform" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file.
```
